### PR TITLE
Texts linked to translation

### DIFF
--- a/resources/views/components/logout.blade.php
+++ b/resources/views/components/logout.blade.php
@@ -1,7 +1,7 @@
 <div class="flex justify-center w-full">
     <form method="POST" action="{{ filament()->getCurrentPanel()->getLogoutUrl() }}">
         <x-filament::link tag="button" type="submit" weight="semibold">
-            Logout
+            {{__('Logout')}}
         </x-filament::link>
     </form>
 </div>

--- a/resources/views/livewire/two-factor-authentication.blade.php
+++ b/resources/views/livewire/two-factor-authentication.blade.php
@@ -11,17 +11,15 @@
         <div class="">
             @if($this->isConfirmingSetup)
                 <h2 class="text-xl font-medium mb-4">
-                    Finish enabling two factor authentication.
+                    {{__('Finish enabling two factor authentication.')}}
                 </h2>
 
                 <p class="text-sm mb-4">
-                    When two factor authentication is enabled, you will be prompted for a secure, random token during
-                    authentication. You may retrieve this token from your phone's Google Authenticator application.
+                    {{__("When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.")}}
                 </p>
 
                 <p class="text-sm font-semibold mb-4">
-                    To finish enabling two factor authentication, scan the following QR code using your phone's
-                    authenticator application or enter the setup key and provide the generated OTP code.
+                    {{__("To finish enabling two factor authentication, scan the following QR code using your phone's authenticator application or enter the setup key and provide the generated OTP code.")}}
                 </p>
 
                 <div class="mb-4">
@@ -39,21 +37,19 @@
                 </form>
             @elseif($this->enableTwoFactorAuthentication->isVisible())
                 <h2 class="text-xl font-medium mb-4">
-                    You have not enabled two factor authentication.
+                    {{__('You have not enabled two factor authentication.')}}
                 </h2>
 
                 <p class="text-sm mb-4">
-                    When two factor authentication is enabled, you will be prompted for a secure, random token during
-                    authentication. You may retrieve this token from your phone's Google Authenticator application.
+                    {{__("When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.")}}
                 </p>
 
                 {{$this->enableTwoFactorAuthentication}}
             @elseif($this->disableTwoFactorAuthentication->isVisible())
-                <h2 class="text-xl font-medium mb-4">You have enabled two factor authentication.</h2>
+                <h2 class="text-xl font-medium mb-4">{{__('You have enabled two factor authentication.')}}</h2>
 
                 <p class="text-sm mb-4">
-                    Store these recovery codes in a secure password manager. They can be used to recover
-                    access to your account if your two factor authentication device is lost.
+                    {{__('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.')}}
                 </p>
 
                 <div class="mb-4 p-4 bg-gray-100 rounded-md">

--- a/resources/views/pages/setup.blade.php
+++ b/resources/views/pages/setup.blade.php
@@ -4,7 +4,7 @@
 
     @if(!filament('filament-two-factor-authentication')->hasEnforcedTwoFactorSetup() || filament()->auth()->user()?->hasEnabledTwoFactorAuthentication())
         <x-filament::link :href="filament()->getCurrentPanel()->getUrl(filament()->getTenant())" weight="semibold">
-            Dashboard
+            {{__('Dashboard')}}
         </x-filament::link>
     @endif
 </x-filament-panels::page.simple>

--- a/src/Livewire/BaseLivewireComponent.php
+++ b/src/Livewire/BaseLivewireComponent.php
@@ -27,7 +27,7 @@ abstract class BaseLivewireComponent extends Component implements HasActions, Ha
 
         if (! $user instanceof Model) {
             throw new Exception(
-                'The authenticated user object must be a Filament Auth model to allow the profile page to update it.'
+                __('The authenticated user object must be a Filament Auth model to allow the profile page to update it.')
             );
         }
 

--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -101,7 +101,7 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                     ->rules([
                         fn () => function (string $attribute, $value, $fail) {
                             if (! Hash::check($value, $this->getUser()->password)) {
-                                $fail('The provided password was incorrect.');
+                                $fail(__('The provided password was incorrect.'));
                             }
                         },
                     ]),
@@ -155,7 +155,7 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                     ->rules([
                         fn () => function (string $attribute, $value, $fail) {
                             if (! Hash::check($value, $this->getUser()->password)) {
-                                $fail('The provided password was incorrect.');
+                                $fail(__('The provided password was incorrect.'));
                             }
                         },
                     ]),

--- a/src/Pages/Challenge.php
+++ b/src/Pages/Challenge.php
@@ -22,7 +22,7 @@ class Challenge extends BaseSimplePage
 
     public function getTitle(): string | Htmlable
     {
-        return 'Two Factor Authentication';
+        return __('Two Factor Authentication');
     }
 
     public function mount(): void


### PR DESCRIPTION
This PR connects the existing text in the project to the translation system. All hardcoded texts were updated to use the `__('text') methods for proper translation integration.

The purpose of these changes is to make the project multilingual-friendly and simplify the process of adding future language support.