### PR TITLE
Fixed dark mode support and dashboard link bug

### DIFF
--- a/resources/views/livewire/two-factor-authentication.blade.php
+++ b/resources/views/livewire/two-factor-authentication.blade.php
@@ -52,7 +52,7 @@
                     {{__('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.')}}
                 </p>
 
-                <div class="mb-4 p-4 bg-gray-100 rounded-md">
+                <div class="mb-4 bg-gray-100 dark:bg-gray-800 dark:text-gray-200 p-4 rounded-md">
                     @foreach($this->getUser()->recoveryCodes() as $code)
                         <p class="text-sm font-medium mb-2">{{$code}}</p>
                     @endforeach
@@ -67,5 +67,11 @@
 
     <x-filament-actions::modals />
 
-    {{-- Success is as dangerous as failure. --}}
+    @if(!filament('filament-two-factor-authentication')->hasEnforcedTwoFactorSetup() || filament()->auth()->user()?->hasEnabledTwoFactorAuthentication())
+        <div class="my-4 text-center">
+            <x-filament::link :href="filament()->getCurrentPanel()->getUrl(filament()->getTenant())" weight="semibold">
+                {{__('Dashboard')}}
+            </x-filament::link>
+        </div>
+    @endif
 </div>

--- a/resources/views/pages/setup.blade.php
+++ b/resources/views/pages/setup.blade.php
@@ -1,10 +1,4 @@
 @php use Stephenjude\FilamentTwoFactorAuthentication\Livewire\TwoFactorAuthentication; @endphp
 <x-filament-panels::page.simple>
     @livewire(TwoFactorAuthentication::class, ['aside' => false, 'redirectTo' => filament()->getCurrentPanel()->getProfileUrl()])
-
-    @if(!filament('filament-two-factor-authentication')->hasEnforcedTwoFactorSetup() || filament()->auth()->user()?->hasEnabledTwoFactorAuthentication())
-        <x-filament::link :href="filament()->getCurrentPanel()->getUrl(filament()->getTenant())" weight="semibold">
-            {{__('Dashboard')}}
-        </x-filament::link>
-    @endif
 </x-filament-panels::page.simple>


### PR DESCRIPTION
Hi @stephenjude 

When using the package on a Filament project, it displays the recovery codes on a gray background which looks good until you switch it to dark mode and the same background stays, with white text making it not be legible, also, on the recovery page, when you're enabling 2fa for the first time, there should be a way to exist the page, but there isn't, not until you refresh and the ddashboard link shows up. This means that livewire is not aware of this link to display it when it repaints the dom

This PR introduces a fix that adds dark mode specific css, and makes livewire aware of the much needed dashboard link.

