### PR TITLE
Introduced Components

### DIFF
--- a/resources/views/components/enable.blade.php
+++ b/resources/views/components/enable.blade.php
@@ -1,0 +1,9 @@
+<h2 class="text-xl font-medium mb-4">
+    {{__('You have not enabled two factor authentication.')}}
+</h2>
+
+<p class="text-sm mb-4">
+    {{__("When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.")}}
+</p>
+
+{{$this->enableTwoFactorAuthentication}}

--- a/resources/views/components/logout.blade.php
+++ b/resources/views/components/logout.blade.php
@@ -1,5 +1,6 @@
 <div class="flex justify-center w-full">
     <form method="POST" action="{{ filament()->getCurrentPanel()->getLogoutUrl() }}">
+        @csrf
         <x-filament::link tag="button" type="submit" weight="semibold">
             {{__('Logout')}}
         </x-filament::link>

--- a/resources/views/components/recovery-codes.blade.php
+++ b/resources/views/components/recovery-codes.blade.php
@@ -1,0 +1,15 @@
+<h2 class="text-xl font-medium mb-4">{{__('You have enabled two factor authentication.')}}</h2>
+
+<p class="text-sm mb-4">
+    {{__('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.')}}
+</p>
+
+<div class="mb-4 bg-gray-100 dark:bg-gray-800 dark:text-gray-200 p-4 rounded-md">
+    @foreach($this->getUser()->recoveryCodes() as $code)
+        <p class="text-sm font-medium mb-2">{{$code}}</p>
+    @endforeach
+</div>
+
+{{$this->generateNewRecoveryCodes}}
+
+{{$this->disableTwoFactorAuthentication}}

--- a/resources/views/components/setup-confirmation.blade.php
+++ b/resources/views/components/setup-confirmation.blade.php
@@ -1,0 +1,25 @@
+<h2 class="text-xl font-medium mb-4">
+    {{__('Finish enabling two factor authentication.')}}
+</h2>
+
+<p class="text-sm mb-4">
+    {{__("When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.")}}
+</p>
+
+<p class="text-sm font-semibold mb-4">
+    {{__("To finish enabling two factor authentication, scan the following QR code using your phone's authenticator application or enter the setup key and provide the generated OTP code.")}}
+</p>
+
+<div class="mb-4">
+    {!! $this->getUser()->twoFactorQrCodeSvg() !!}
+</div>
+
+<form wire:submit="confirmSetup">
+    <div class="mb-4">
+        {{ $this->form }}
+    </div>
+    <div class="flex gap-2">
+        {{$this->confirmSetup}}
+        {{$this->cancelSetup}}
+    </div>
+</form>

--- a/resources/views/livewire/two-factor-authentication.blade.php
+++ b/resources/views/livewire/two-factor-authentication.blade.php
@@ -10,57 +10,11 @@
 
         <div class="">
             @if($this->isConfirmingSetup)
-                <h2 class="text-xl font-medium mb-4">
-                    {{__('Finish enabling two factor authentication.')}}
-                </h2>
-
-                <p class="text-sm mb-4">
-                    {{__("When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.")}}
-                </p>
-
-                <p class="text-sm font-semibold mb-4">
-                    {{__("To finish enabling two factor authentication, scan the following QR code using your phone's authenticator application or enter the setup key and provide the generated OTP code.")}}
-                </p>
-
-                <div class="mb-4">
-                    {!! $this->getUser()->twoFactorQrCodeSvg() !!}
-                </div>
-
-                <form wire:submit="confirmSetup">
-                    <div class="mb-4">
-                        {{ $this->form }}
-                    </div>
-                    <div class="flex gap-2">
-                        {{$this->confirmSetup}}
-                        {{$this->cancelSetup}}
-                    </div>
-                </form>
+                <x-filament-two-factor-authentication::setup-confirmation />
             @elseif($this->enableTwoFactorAuthentication->isVisible())
-                <h2 class="text-xl font-medium mb-4">
-                    {{__('You have not enabled two factor authentication.')}}
-                </h2>
-
-                <p class="text-sm mb-4">
-                    {{__("When two factor authentication is enabled, you will be prompted for a secure, random token during authentication. You may retrieve this token from your phone's Google Authenticator application.")}}
-                </p>
-
-                {{$this->enableTwoFactorAuthentication}}
+                <x-filament-two-factor-authentication::enable />
             @elseif($this->disableTwoFactorAuthentication->isVisible())
-                <h2 class="text-xl font-medium mb-4">{{__('You have enabled two factor authentication.')}}</h2>
-
-                <p class="text-sm mb-4">
-                    {{__('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.')}}
-                </p>
-
-                <div class="mb-4 bg-gray-100 dark:bg-gray-800 dark:text-gray-200 p-4 rounded-md">
-                    @foreach($this->getUser()->recoveryCodes() as $code)
-                        <p class="text-sm font-medium mb-2">{{$code}}</p>
-                    @endforeach
-                </div>
-
-                {{$this->generateNewRecoveryCodes}}
-
-                {{$this->disableTwoFactorAuthentication}}
+                <x-filament-two-factor-authentication::recovery-codes />
             @endif
         </div>
     </x-filament::section>
@@ -72,6 +26,12 @@
             <x-filament::link :href="filament()->getCurrentPanel()->getUrl(filament()->getTenant())" weight="semibold">
                 {{__('Dashboard')}}
             </x-filament::link>
+        </div>
+    @endif
+
+    @if($this->enableTwoFactorAuthentication->isVisible())
+        <div class="my-4 text-center">
+            <x-filament-two-factor-authentication::logout />
         </div>
     @endif
 </div>

--- a/resources/views/pages/challenge.blade.php
+++ b/resources/views/pages/challenge.blade.php
@@ -8,8 +8,8 @@
         {{ $this->form }}
 
         <x-filament-panels::form.actions
-                :actions="$this->getCachedFormActions()"
-                :full-width="$this->hasFullWidthFormActions()"
+            :actions="$this->getCachedFormActions()"
+            :full-width="$this->hasFullWidthFormActions()"
         />
     </x-filament-panels::form>
 

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -53,7 +53,7 @@ trait TwoFactorAuthenticatable
     public function twoFactorQrCodeSvg(): string
     {
         $svg = (new Writer(
-            new ImageRenderer(
+                new ImageRenderer(
                 new RendererStyle(192, 0, null, null, Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(45, 55, 72))),
                 new SvgImageBackEnd
             )


### PR DESCRIPTION
This PR introduces blade components to the livewire components that power 2FA setup, making it cleaner and seperating concerns based on setup stage.

It also adds a logout button on the setup 2fa page, giving user ability to signout of an account if they are not ready or do not have the ability to setup 2FA at the time of logging in.

Added `@csrf` tag to logout component to avoid page expired when trying to logout.