### PR TITLE
Fixed incomplete Arr import on Login.php

### DIFF
--- a/src/Pages/Login.php
+++ b/src/Pages/Login.php
@@ -2,7 +2,7 @@
 
 namespace Stephenjude\FilamentTwoFactorAuthentication\Pages;
 
-use Arr;
+use Illuminate\Support\Arr;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Filament\Facades\Filament;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse;


### PR DESCRIPTION
The import `use Arr;` used at line 50: `$user = $model::where(Arr::only($data, 'email'))->first();` was causing a class not found error. 
Changed to `use Illuminate\Support\Arr`