### PR TITLE
fixing no api-prefix in url

### DIFF
--- a/src/EnforceTwoFactorSetup.php
+++ b/src/EnforceTwoFactorSetup.php
@@ -11,7 +11,7 @@ class EnforceTwoFactorSetup
     {
         $user = filament()->auth()->user();
 
-        if ($request->is('*/logout') || $request->is('*/profile')) {
+        if ($request->is('*/logout') || $request->is('logout') || $request->is('*/profile')) {
             return $next($request);
         }
 


### PR DESCRIPTION
fixes #15 

I figured out the problem: 
I removed the api-prefix for my app so instead of `{url}/admin/logout` , the request is `{url}/logout`

The PR fixes, checking if the request is also 'logout' instead of only '*/logout'