### PR TITLE
Fix QR code scanning issue in dark mode by adding white padding

### DIFF
--- a/resources/views/components/setup-confirmation.blade.php
+++ b/resources/views/components/setup-confirmation.blade.php
@@ -10,7 +10,7 @@
     {{__("To finish enabling two factor authentication, scan the following QR code using your phone's authenticator application or enter the setup key and provide the generated OTP code.")}}
 </p>
 
-<div class="mb-4">
+<div class="mb-4 p-2 bg-white inline-block rounded-lg">
     {!! $this->getUser()->twoFactorQrCodeSvg() !!}
 </div>
 


### PR DESCRIPTION
## Issue
- QR code was not scannable in dark mode when using Google Authenticator or Microsoft Authenticator.
- The dark background made the QR code unreadable.

## Fix
- Added a `bg-white` background with `p-2` padding to improve contrast.
- Ensured the QR code remains scannable in all themes.

## Testing
- Tested with Google Authenticator and Microsoft Authenticator in both light and dark modes.
- QR code is now scannable in all conditions.
