### PR TITLE
Feature: Configure if password is needed when enabling/disabling 2fa

### DIFF
--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -12,6 +12,7 @@ use Stephenjude\FilamentTwoFactorAuthentication\Actions\ConfirmTwoFactorAuthenti
 use Stephenjude\FilamentTwoFactorAuthentication\Actions\DisableTwoFactorAuthentication;
 use Stephenjude\FilamentTwoFactorAuthentication\Actions\EnableTwoFactorAuthentication;
 use Stephenjude\FilamentTwoFactorAuthentication\Actions\GenerateNewRecoveryCodes;
+use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticationPlugin;
 
 class TwoFactorAuthentication extends BaseLivewireComponent
 {
@@ -91,8 +92,13 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                 fn () => ! $this->getUser()->hasEnabledTwoFactorAuthentication()
             )->modalWidth('md')
             ->modalSubmitActionLabel(__('Confirm'))
-            ->form([
-                TextInput::make('confirmPassword')
+            ->form(function () {
+
+                if (! TwoFactorAuthenticationPlugin::get()->isPasswordRequiredForEnable()) {
+                    return null;
+                }
+
+                return [TextInput::make('confirmPassword')
                     ->label(__('Confirm Password'))
                     ->password()
                     ->revealable(filament()->arePasswordsRevealable())
@@ -105,7 +111,8 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                             }
                         },
                     ]),
-            ])
+                ];
+            })
             ->action(function () {
                 try {
                     $this->rateLimit(5);
@@ -145,8 +152,13 @@ class TwoFactorAuthentication extends BaseLivewireComponent
             ->visible(fn () => $this->getUser()->hasEnabledTwoFactorAuthentication())
             ->modalWidth('md')
             ->modalSubmitActionLabel(__('Confirm'))
-            ->form([
-                TextInput::make('currentPassword')
+            ->form(function () {
+
+                if (! TwoFactorAuthenticationPlugin::get()->isPasswordRequiredForDisable()) {
+                    return null;
+                }
+
+                return [TextInput::make('currentPassword')
                     ->label(__('Current Password'))
                     ->password()
                     ->revealable(filament()->arePasswordsRevealable())
@@ -159,7 +171,8 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                             }
                         },
                     ]),
-            ])
+                ];
+            })
             ->action(fn () => app(DisableTwoFactorAuthentication::class)($this->getUser()));
     }
 

--- a/src/TwoFactorAuthenticationPlugin.php
+++ b/src/TwoFactorAuthenticationPlugin.php
@@ -2,10 +2,12 @@
 
 namespace Stephenjude\FilamentTwoFactorAuthentication;
 
+use Closure;
 use Filament\Contracts\Plugin;
 use Filament\Facades\Filament;
 use Filament\Navigation\MenuItem;
 use Filament\Panel;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Support\Facades\Route;
 use Stephenjude\FilamentTwoFactorAuthentication\Pages\Challenge;
 use Stephenjude\FilamentTwoFactorAuthentication\Pages\Login;
@@ -14,6 +16,8 @@ use Stephenjude\FilamentTwoFactorAuthentication\Pages\Setup;
 
 class TwoFactorAuthenticationPlugin implements Plugin
 {
+    use EvaluatesClosures;
+
     protected bool $hasEnforcedTwoFactorSetup = false;
 
     protected bool $hasTwoFactorMenuItem = false;
@@ -21,6 +25,10 @@ class TwoFactorAuthenticationPlugin implements Plugin
     protected ?string $twoFactorMenuItemLabel = null;
 
     protected ?string $twoFactorMenuItemIcon = null;
+
+    protected bool | Closure $isPasswordRequiredForEnable = true;
+
+    protected bool | Closure $isPasswordRequiredForDisable = true;
 
     public function getId(): string
     {
@@ -53,6 +61,30 @@ class TwoFactorAuthenticationPlugin implements Plugin
                     EnforceTwoFactorSetup::class,
                 ]);
         }
+    }
+
+    public function requirePasswordWhenEnabling(bool | Closure $condition = true): static
+    {
+        $this->isPasswordRequiredForEnable = $condition;
+
+        return $this;
+    }
+
+    public function requirePasswordWhenDisabling(bool | Closure $condition = true): static
+    {
+        $this->isPasswordRequiredForDisable = $condition;
+
+        return $this;
+    }
+
+    public function isPasswordRequiredForEnable(): bool
+    {
+        return $this->evaluate($this->isPasswordRequiredForEnable);
+    }
+
+    public function isPasswordRequiredForDisable(): bool
+    {
+        return $this->evaluate($this->isPasswordRequiredForDisable);
     }
 
     public function enforceTwoFactorSetup(bool $condition = true): static


### PR DESCRIPTION
Hello,

This PR resolves #17 and introduces two new configuration methods:
- `requirePasswordWhenEnabling(true/false/closure)`
- `requirePasswordWhenDisabling(true/false/closure)`

By default, both options are enabled for backward compatibility.

If you provide a closure, you can add custom logic - like checking if the environment is production or if the user is an admin etc.