### PR TITLE
Feature: password required for regenerate recovery codes

### DIFF
--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -154,7 +154,7 @@ class TwoFactorAuthentication extends BaseLivewireComponent
             ->color('danger')
             ->visible(fn () => $this->getUser()->hasEnabledTwoFactorAuthentication())
             ->modalWidth('md')
-            ->modalSubmitActionLabel(__('Confirm'))
+            ->modalSubmitActionLabel(__('filament-two-factor-authentication::components.2fa.confirm'))
             ->form(function () {
 
                 if (! TwoFactorAuthenticationPlugin::get()->isPasswordRequiredForDisable()) {

--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -170,7 +170,7 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                     ->rules([
                         fn () => function (string $attribute, $value, $fail) {
                             if (! Hash::check($value, $this->getUser()->password)) {
-                                $fail(__('The provided password was incorrect.'));
+                                $fail(__('filament-two-factor-authentication::components.2fa.wrong_password'));
                             }
                         },
                     ]),

--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -162,7 +162,7 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                 }
 
                 return [TextInput::make('currentPassword')
-                    ->label(__('Current Password'))
+                    ->label(__('filament-two-factor-authentication::components.2fa.current_password'))
                     ->password()
                     ->revealable(filament()->arePasswordsRevealable())
                     ->required()

--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -93,10 +93,10 @@ class TwoFactorAuthentication extends BaseLivewireComponent
             ->label(__('Enable'))
             ->visible(
                 fn () => ! $this->getUser()->hasEnabledTwoFactorAuthentication()
-            )->modalWidth('md')
+            )
+            ->modalWidth('md')
             ->modalSubmitActionLabel(__('Confirm'))
             ->form(function () {
-
                 if (! TwoFactorAuthenticationPlugin::get()->isPasswordRequiredForEnable()) {
                     return null;
                 }
@@ -185,7 +185,30 @@ class TwoFactorAuthentication extends BaseLivewireComponent
             ->label(__('Regenerate Recovery Codes'))
             ->outlined()
             ->visible(fn () => $this->getUser()->hasEnabledTwoFactorAuthentication())
-            ->requiresConfirmation()
+
+            ->requiresConfirmation(! TwoFactorAuthenticationPlugin::get()->isPasswordRequiredForRegenerateRecoveryCodes())
+            ->modalWidth('md')
+            ->modalSubmitActionLabel(__('Confirm'))
+            ->form(function () {
+                if (! TwoFactorAuthenticationPlugin::get()->isPasswordRequiredForRegenerateRecoveryCodes()) {
+                    return null;
+                }
+
+                return [TextInput::make('currentPassword')
+                    ->label(__('Current Password'))
+                    ->password()
+                    ->revealable(filament()->arePasswordsRevealable())
+                    ->required()
+                    ->autocomplete('current-password')
+                    ->rules([
+                        fn () => function (string $attribute, $value, $fail) {
+                            if (! Hash::check($value, $this->getUser()->password)) {
+                                $fail(__('The provided password was incorrect.'));
+                            }
+                        },
+                    ]),
+                ];
+            })
             ->action(
                 function () {
                     $this->showRecoveryCodes = true;

--- a/src/TwoFactorAuthenticationPlugin.php
+++ b/src/TwoFactorAuthenticationPlugin.php
@@ -30,6 +30,8 @@ class TwoFactorAuthenticationPlugin implements Plugin
 
     protected bool | Closure $isPasswordRequiredForDisable = true;
 
+    protected bool | Closure $isPasswordRequiredForRegenerateRecoveryCodes = true;
+
     public function getId(): string
     {
         return 'filament-two-factor-authentication';
@@ -75,6 +77,18 @@ class TwoFactorAuthenticationPlugin implements Plugin
         $this->isPasswordRequiredForDisable = $condition;
 
         return $this;
+    }
+
+    public function requirePasswordWhenRegeneratingRecoveryCodes(bool | Closure $condition = true): static
+    {
+        $this->isPasswordRequiredForRegenerateRecoveryCodes = $condition;
+
+        return $this;
+    }
+
+    public function isPasswordRequiredForRegenerateRecoveryCodes(): bool
+    {
+        return $this->evaluate($this->isPasswordRequiredForRegenerateRecoveryCodes);
     }
 
     public function isPasswordRequiredForEnable(): bool


### PR DESCRIPTION
This option is enabled by default, because it can be potential security vulnerability if disabled.

Of course behavior can be changed using 'requirePasswordWhenRegeneratingRecoveryCodes()' method on plugin.

PR already contain keys for translating (#29).

