### PR TITLE
Fix page reload error

### DIFF
--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -35,7 +35,6 @@ trait TwoFactorAuthenticatable
         $sessionValue = Hash::make($this->two_factor_secret);
 
         session()->put($sessionKey, $sessionValue);
-        // session()->regenerate();
     }
 
     /**

--- a/src/TwoFactorAuthenticatable.php
+++ b/src/TwoFactorAuthenticatable.php
@@ -35,7 +35,7 @@ trait TwoFactorAuthenticatable
         $sessionValue = Hash::make($this->two_factor_secret);
 
         session()->put($sessionKey, $sessionValue);
-        session()->regenerate();
+        // session()->regenerate();
     }
 
     /**


### PR DESCRIPTION
Fixes this issue: https://github.com/stephenjude/filament-two-factor-authentication/issues/36

Regenerating the session after `setTwoFactorChallengePassed()` was causing the page to force a reload.