### PR TITLE
Fix #47

### DIFF
--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -208,6 +208,6 @@ class TwoFactorAuthentication extends BaseLivewireComponent
                     ]),
                 ];
             })
-            ->action(fn () => app(GenerateNewRecoveryCodes::class)($this->getUser()));
+            ->action(fn () => $this->showRecoveryCodes = true, app(GenerateNewRecoveryCodes::class)($this->getUser()));
     }
 }


### PR DESCRIPTION
A simple fix is to show recovery codes by clicking the "Generate New Recovery Codes" button.
This PR does not include any fixes to show recovery codes after installation finishes, maybe I'll provide a fix later.