### PR TITLE
Add check for current panel in ServiceProvider.

### DIFF
--- a/src/TwoFactorAuthenticationServiceProvider.php
+++ b/src/TwoFactorAuthenticationServiceProvider.php
@@ -86,7 +86,7 @@ class TwoFactorAuthenticationServiceProvider extends PackageServiceProvider
             PasskeyAuthentication::class
         );
 
-        if (filament()->hasPlugin('filament-two-factor-authentication') && TwoFactorAuthenticationPlugin::get()->hasEnabledPasskeyAuthentication()) {
+        if (filament()->getCurrentPanel() && filament()->hasPlugin('filament-two-factor-authentication') && TwoFactorAuthenticationPlugin::get()->hasEnabledPasskeyAuthentication()) {
             $this->configurePasskey();
 
             FilamentAsset::register([


### PR DESCRIPTION
When calling `filament()->hasPlugin('filament-two-factor-authentication')`, under the hood it will call the following from the `FilamentManager` class:

```php
    public function hasPlugin(string $id): bool
    {
        return $this->getCurrentPanel()->hasPlugin($id);
    }
```

The issue is that the `getCurrentPanel()` method can return `null` and when running a command, such as phpstan, we don't always have a panel booted, resulting in the following error:

> Error thrown in /../vendor/filament/filament/src/FilamentManager.php on line 601 while loading bootstrap file /../vendor/larastan/larastan/bootstrap.php: Call to a member function hasPlugin() on null

By adding a check to ensure we have a current panel this error should go away.