### PR TITLE
[2.x] Set the intended URL before redirecting to the challenge

### DIFF
--- a/src/Middleware/TwoFactorChallenge.php
+++ b/src/Middleware/TwoFactorChallenge.php
@@ -19,7 +19,7 @@ class TwoFactorChallenge
             ! $user?->isTwoFactorChallengePassed() &&
             ! $user?->passkeyAuthenticated()
         ) {
-            return redirect()->to($this->twoFactorChallengeRoute());
+            return redirect()->guest($this->twoFactorChallengeRoute());
         }
 
         return $next($request);


### PR DESCRIPTION
Fixes #44

The guest method on redirect sets the intended URL before redirecting. This fixes an issue where you would always be taken to the filament panel root page even if you tried to visit another route before before passing the 2FA challenge.