### PR TITLE
Display a button to redirect to the home page after verifying the code directly without having to reload the page for it to appear.

### DIFF
--- a/resources/views/pages/setup.blade.php
+++ b/resources/views/pages/setup.blade.php
@@ -14,6 +14,4 @@
     @if($plugin->hasEnabledPasskeyAuthentication())
         @livewire(PasskeyAuthentication::class, ['aside' => false])
     @endif
-
-    {{$this->utilityActionsForm}}
 </x-filament-panels::page.simple>

--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -46,7 +46,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
             ->live()
             ->statePath('data')
             ->model($this->getUser())
-            ->hidden(fn () => ! $this->showSetupCode)
+            ->hidden(fn() => ! $this->showSetupCode)
             ->components([
                 TextEntry::make('header')
                     ->hiddenLabel()
@@ -64,10 +64,10 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
                 TextEntry::make('qrcode')
                     ->hiddenLabel()
                     ->state(
-                        fn ($record) => $record->two_factor_secret ? new HtmlString($record->twoFactorQrCodeSvg()) : ''
+                        fn($record) => $record->two_factor_secret ? new HtmlString($record->twoFactorQrCodeSvg()) : ''
                     ),
                 TextEntry::make('setup_key')
-                    ->label(fn ($record) => __('filament-two-factor-authentication::components.2fa.setup_key', [
+                    ->label(fn($record) => __('filament-two-factor-authentication::components.2fa.setup_key', [
                         'setup_key' => $record->two_factor_secret ? decrypt($record->two_factor_secret) : '',
                     ])),
                 TextInput::make('code')
@@ -101,7 +101,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
             ->live()
             ->statePath('data')
             ->model($this->getUser())
-            ->hidden(fn ($record) => $record->hasEnabledTwoFactorAuthentication() || $this->showSetupCode)
+            ->hidden(fn($record) => $record->hasEnabledTwoFactorAuthentication() || $this->showSetupCode)
             ->components([
                 TextEntry::make('header')
                     ->hiddenLabel()
@@ -132,7 +132,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
                                     ->required()
                                     ->autocomplete('confirm-password')
                                     ->rules([
-                                        fn () => function (string $attribute, $value, $fail) {
+                                        fn() => function (string $attribute, $value, $fail) {
                                             if (! Hash::check($value, $this->getUser()->password)) {
                                                 $fail(
                                                     __(
@@ -154,25 +154,31 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
             ->live()
             ->statePath('data')
             ->model($this->getUser())
-            ->hidden(fn () => ! $this->getUser()->hasEnabledTwoFactorAuthentication())
+            ->hidden(fn() => ! $this->getUser()->hasEnabledTwoFactorAuthentication())
             ->components([
                 TextEntry::make('recoveryCode')
                     ->hiddenLabel()
                     ->listWithLineBreaks()
                     ->copyable()
                     ->state(
-                        fn () => $this->getUser()->hasEnabledTwoFactorAuthentication()
+                        fn() => $this->getUser()->hasEnabledTwoFactorAuthentication()
                             ? $this->getUser()->recoveryCodes()
                             : []
                     ),
                 Actions::make([
+                    Action::make('dashboard')
+                        ->label(__('filament-two-factor-authentication::section.dashboard'))
+                        ->url(fn() => \filament()->getCurrentOrDefaultPanel()->getUrl())
+                        ->color('primary')
+                        ->icon('heroicon-o-home')
+                        ->button(),
                     Action::make('generateNewRecoveryCodes')
                         ->label(__('filament-two-factor-authentication::components.2fa.regenerate_recovery_codes'))
                         ->outlined()
                         ->requiresConfirmation(! TwoFactorAuthenticationPlugin::get()->twoFactorSetupRequiresPassword())
                         ->modalWidth('md')
                         ->modalSubmitActionLabel(__('filament-two-factor-authentication::components.2fa.confirm'))
-                        ->action(fn ($record) => app(GenerateNewRecoveryCodes::class)($record))
+                        ->action(fn($record) => app(GenerateNewRecoveryCodes::class)($record))
                         ->schema(function () {
                             if (! TwoFactorAuthenticationPlugin::get()->twoFactorSetupRequiresPassword()) {
                                 return null;
@@ -186,7 +192,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
                                     ->required()
                                     ->autocomplete('current-password')
                                     ->rules([
-                                        fn () => function (string $attribute, $value, $fail) {
+                                        fn() => function (string $attribute, $value, $fail) {
                                             if (! Hash::check($value, $this->getUser()->password)) {
                                                 $fail(
                                                     __(
@@ -203,7 +209,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
                         ->color('danger')
                         ->modalWidth('md')
                         ->modalSubmitActionLabel(__('filament-two-factor-authentication::components.2fa.confirm'))
-                        ->action(fn ($record) => app(DisableTwoFactorAuthentication::class)($record))
+                        ->action(fn($record) => app(DisableTwoFactorAuthentication::class)($record))
                         ->requiresConfirmation()
                         ->schema(function () {
                             if (! TwoFactorAuthenticationPlugin::get()->twoFactorSetupRequiresPassword()) {
@@ -218,7 +224,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
                                     ->required()
                                     ->autocomplete('current-password')
                                     ->rules([
-                                        fn () => function (string $attribute, $value, $fail) {
+                                        fn() => function (string $attribute, $value, $fail) {
                                             if (! Hash::check($value, $this->getUser()->password)) {
                                                 $fail(
                                                     __(

--- a/src/Pages/Setup.php
+++ b/src/Pages/Setup.php
@@ -2,12 +2,8 @@
 
 namespace Stephenjude\FilamentTwoFactorAuthentication\Pages;
 
-use Filament\Actions\Action;
 use Filament\Facades\Filament;
-use Filament\Schemas\Components\Actions;
-use Filament\Schemas\Schema;
 use Illuminate\Contracts\Support\Htmlable;
-use Stephenjude\FilamentTwoFactorAuthentication\TwoFactorAuthenticationPlugin;
 
 class Setup extends BaseSimplePage
 {
@@ -25,24 +21,5 @@ class Setup extends BaseSimplePage
     public function getTitle(): string | Htmlable
     {
         return '';
-    }
-
-    public function utilityActionsForm(Schema $schema): Schema
-    {
-        return $schema
-            ->components([
-                Actions::make([
-                    Action::make('dashboard')
-                        ->visible(
-                            ! TwoFactorAuthenticationPlugin::get()->hasForcedTwoFactorSetup()
-                            || filament()->auth()->user()->hasEnabledTwoFactorAuthentication()
-                        )
-                        ->label(__('filament-two-factor-authentication::section.dashboard'))
-                        ->url(fn () => \filament()->getCurrentOrDefaultPanel()->getUrl())
-                        ->color('gray')
-                        ->icon('heroicon-o-home')
-                        ->link(),
-                ])->fullWidth(),
-            ]);
     }
 }


### PR DESCRIPTION
When the user is asked to activate two-factor authentication and the code entered is verified,
the user is forced to reload the page to see a button that directs them to the dashboard home page.
See the difference in the pictures:

before:
After check code:
<img width="540" height="526" alt="Screenshot from 2025-09-19 12-16-23" src="https://github.com/user-attachments/assets/c7ffa152-9555-43c0-adab-59390cc3ddb3" />
Then you need to refresh the page for the dashboard link to appear (photo after refersh)
<img width="540" height="526" alt="Screenshot from 2025-09-19 12-16-27" src="https://github.com/user-attachments/assets/d433aab3-0bad-4e91-ad81-a82507ab1c05" />

after:
After check code:
<img width="540" height="526" alt="Screenshot from 2025-09-19 12-15-10" src="https://github.com/user-attachments/assets/73ebae24-91c3-4b49-afa2-59a618cb1a79" />
It is easier and clearer for the user.