### PR TITLE
Reactive dashboard link after verifying the code

### DIFF
--- a/src/Livewire/TwoFactorAuthentication.php
+++ b/src/Livewire/TwoFactorAuthentication.php
@@ -82,6 +82,7 @@ class TwoFactorAuthentication extends Component implements HasActions, HasForms
                             app(ConfirmTwoFactorAuthentication::class)($record, $data['code']);
 
                             $this->showSetupCode = false;
+                            $this->dispatch('refresh-page');
                         }),
                     Action::make('cancel')
                         ->label(__('filament-two-factor-authentication::components.2fa.cancel'))


### PR DESCRIPTION
After check code 2fa will be show dashboard link without need to reload page
<img width="538" height="543" alt="image" src="https://github.com/user-attachments/assets/fba4cd7b-987b-4579-a915-af0c999542f3" />
This request improves on idea #86  to make it easier for users by allowing them to add the component to their profile page without the annoying home page button appearing.