### PR TITLE
Remove duplicated requires from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,8 @@
     ],
     "require": {
         "php": "^8.3",
-        "filament/filament": "^4.0",
-        "pragmarx/google2fa": "^8.0|^9.0",
         "filament/filament": "^4.0|^5.0",
-        "pragmarx/google2fa": "^8.0",
+        "pragmarx/google2fa": "^8.0|^9.0",
         "bacon/bacon-qr-code": "^3.0",
         "spatie/laravel-passkeys": "^1.0",
         "spatie/laravel-package-tools": "^1.15.0"


### PR DESCRIPTION
I'm currently trying to upgrade the filament-jetstream package on my local for Filament 4 -> Filament 5. It was saying this package doesn't support 5.0 but i found the issue with the composer json having duplicated rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded dependency version constraints to support both current stable releases and next-generation major versions of key framework and authentication packages, improving overall application compatibility and providing flexibility for users to adopt newer versions when ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->